### PR TITLE
refactor(kernel): 优化内核关闭逻辑并移除多余日志

### DIFF
--- a/app/interfaces/canvas_interaface/main_widget.py
+++ b/app/interfaces/canvas_interaface/main_widget.py
@@ -672,26 +672,28 @@ class CanvasPage(QWidget):
 
     # --- 画布关闭逻辑 ---
     def close_current_canvas(self):
-        if not self.file_path.exists():
-            self.clean_canvas()
+        try:
+            if not self.file_path.exists():
+                self.clean_canvas()
 
-        # 清除注册的触发器
-        for manager in ALL_MANAGERS:
-            try:
-                manager.remove_by_canvas(self.workflow_name)
-                logger.info(f"已清理管理器 [{manager.manager_name}] 中的画布: {self.workflow_name}")
-            except Exception as e:
-                logger.error(f"清理管理器 {manager.manager_name} 失败: {e}")
+            # 清除注册的触发器
+            for manager in ALL_MANAGERS:
+                try:
+                    manager.remove_by_canvas(self.workflow_name)
+                except Exception as e:
+                    logger.exception(f"清理管理器 {manager.manager_name} 失败: {e}")
         # 定时器关闭
-        self._auto_saver.stop()
-        self.ipython_kernel.stop_kernel()
-        self._disconnect_signals()
-        self.ui_manager.destroy_all()
-        self.canvas_runner.stop_workflow()
-        self.graph.deleteLater()
-        self.canvas_deleted.emit()
-        self.parent.removeInterface(self)
-        self.deleteLater()
+            self._auto_saver.stop()
+            self.ipython_kernel.stop_kernel()
+            self._disconnect_signals()
+            self.ui_manager.destroy_all()
+            self.canvas_runner.stop_workflow()
+            self.graph.deleteLater()
+            self.canvas_deleted.emit()
+            self.parent.removeInterface(self)
+            self.deleteLater()
+        except:
+            logger.exception("关闭画布时发生错误")
 
     def clean_canvas(self):
         def cleanup_task():

--- a/app/server_manager/ipython_server/ipython_kernel_manager.py
+++ b/app/server_manager/ipython_server/ipython_kernel_manager.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from loguru import logger
 
@@ -30,30 +31,6 @@ class LocalConnectWorker(QThread):
                 self.finished.emit(False, "本地内核启动失败，请检查 Python 路径")
         except Exception as e:
             self.finished.emit(False, str(e))
-
-
-class KernelShutdownWorker(QThread):
-    """
-    后台关闭工人：负责在不阻塞 UI 的情况下关闭内核。
-    """
-    finished = pyqtSignal()
-
-    def __init__(self, kernel_manager, kernel_client):
-        super().__init__()
-        self.km = kernel_manager
-        self.kc = kernel_client
-
-    def run(self):
-        try:
-            if self.kc:
-                self.kc.stop_channels()
-            if self.km:
-                # now=True 表示立即发送 SIGKILL，不等待内核优雅退出
-                self.km.shutdown_kernel(now=True)
-        except Exception as e:
-            logger.error(f"后台关闭内核失败: {e}")
-        finally:
-            self.finished.emit()
 
 
 class IPythonKernelManager:
@@ -146,34 +123,34 @@ class IPythonKernelManager:
                 logger.error(f"中断 kernel 失败: {e}")
         return False
 
-    def shutdown_kernel(self, async_mode=True):
+    def shutdown_kernel(self, **kwargs):
         """
-        关闭内核
-        :param async_mode: 是否使用线程异步关闭。UI 调用时务必设为 True。
+        [同步关闭]
+        因为使用了 now=True，这通常是发送 SIGKILL，速度非常快（<10ms）。
+        在此处使用 QThread 是过度设计，且是导致崩溃的根源。
         """
-        km = self.kernel_manager
-        kc = self.kernel_client
+        try:
+            if self.kernel_client:
+                # 停止通道必须在创建它的线程（主线程）调用
+                self.kernel_client.stop_channels()
+                self.kernel_client = None
 
-        # 清空当前引用，防止重复操作
-        self.kernel_manager = None
-        self.kernel_client = None
+            if self.kernel_manager:
+                # now=True 表示强制杀进程，不要等待
+                if self.kernel_manager.has_kernel:
+                    self.kernel_manager.shutdown_kernel(now=True)
+                self.kernel_manager = None
 
-        if not km:
-            return
+            # 清理临时文件
+            if self.connection_file and os.path.exists(self.connection_file):
+                try:
+                    os.remove(self.connection_file)
+                except:
+                    pass
 
-        if async_mode:
-            # 开启后台线程处理
-            self._shutdown_worker = KernelShutdownWorker(km, kc)
-            # 线程结束后自动清理引用
-            self._shutdown_worker.finished.connect(lambda: setattr(self, '_shutdown_worker', None))
-            self._shutdown_worker.start()
-        else:
-            # 同步模式（仅在非 UI 线程中使用）
-            try:
-                if kc: kc.stop_channels()
-                km.shutdown_kernel(now=True)
-            except:
-                pass
+            logger.info("内核已关闭")
+        except Exception as e:
+            logger.error(f"关闭内核时出错: {e}")
 
     def is_alive(self):
         """内核是否存活"""

--- a/app/trigger_plugins/base_trigger.py
+++ b/app/trigger_plugins/base_trigger.py
@@ -76,7 +76,6 @@ class BaseTriggerManager(ABC):
 
             if canvas_name in self.canvas_mapping:
                 del self.canvas_mapping[canvas_name]
-            logger.info(f"[{self.manager_name}] 已清理画布 '{canvas_name}' 的所有触发项")
 
     @abstractmethod
     def stop(self):

--- a/build.py
+++ b/build.py
@@ -9,7 +9,7 @@ import spyder
 # 1. 基础路径配置
 base_dir = os.path.dirname(os.path.abspath(__file__))
 env_dir = str(Path(os.path.dirname(spyder.__file__)).parent)
-extra_modules = ["spyder", "fastapi", "watchdog", "uvicorn", "starlette", "pyecharts", "paho", "redis", "sqlalchemy", "psutil"]
+extra_modules = ["spyder", "fastapi", "watchdog", "uvicorn", "starlette", "pyecharts", "paho", "redis", "sqlalchemy", "psutil", "prettytable"]
 
 # 3. 构造参数列表
 params = [


### PR DESCRIPTION
- 移除画布清理时的冗余日志输出
- 在打包配置中添加 prettytable 依赖模块
- 移除 KernelShutdownWorker 线程类，简化内核关闭实现
- 将 shutdown_kernel 方法改为同步方式，提高关闭速度
- 添加连接文件清理功能
- 在画布关闭时添加异常处理保护
- 优化触发器清理逻辑并改进错误处理